### PR TITLE
Rename master branch to main in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ name: "IGListKit CI"
 on: 
   push:
     branches: 
-      - master
+      - main
   pull_request:
     branches: 
       - '*'


### PR DESCRIPTION
The master branch was never renamed to main in the CI, meaning integration wasn't getting tested on new PRs being pushed.